### PR TITLE
docs(README): remove nix-shell git

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,6 @@ sway 与 hyprland 外观一致,此处展示的是hyprland
 ```
 4. 克隆仓库到本地
 ```bash
-nix-shell -p git
 git clone  https://github.com/Ruixi-rebirth/flakes.git /mnt/etc/nixos/Flakes 
 cd  /mnt/etc/nixos/Flakes/
 nix develop --extra-experimental-features nix-command --extra-experimental-features flakes

--- a/README_en.md
+++ b/README_en.md
@@ -20,7 +20,6 @@
 ```
 4. Clone the repository locally 
 ```bash
-nix-shell -p git
 git clone  https://github.com/Ruixi-rebirth/flakes.git /mnt/etc/nixos/Flakes 
 cd /mnt/etc/nixos/Flakes/
 nix develop --extra-experimental-features nix-command --extra-experimental-features flakes 


### PR DESCRIPTION
  1. It seem no reason to use `nix-shell -p git` to go into a environment with git, Which because the NixOS live is already have git.