### PR TITLE
fix[polkit]: add user service for polkit-gnome authentication

### DIFF
--- a/hosts/laptop/wayland/default.nix
+++ b/hosts/laptop/wayland/default.nix
@@ -156,6 +156,21 @@
     };
   };
 
+  systemd = {
+    user.services.polkit-gnome-authentication-agent-1 = {
+      description = "polkit-gnome-authentication-agent-1";
+      wantedBy = [ "graphical-session.target" ];
+      wants = [ "graphical-session.target" ];
+      after = [ "graphical-session.target" ];
+      serviceConfig = {
+        Type = "simple";
+        ExecStart = "${pkgs.polkit_gnome}/libexec/polkit-gnome-authentication-agent-1";
+        Restart = "on-failure";
+        RestartSec = 1;
+        TimeoutStopSec = 10;
+      };
+    };
+  };
   security.polkit.enable = true;
   security.sudo = {
     enable = false;

--- a/hosts/system.nix
+++ b/hosts/system.nix
@@ -55,6 +55,7 @@
       rar
       frp
       sops
+      polkit_gnome
       # sbctl
     ];
   };


### PR DESCRIPTION
Fix the authentication for mounting disks in nemo file browser.